### PR TITLE
Use the menu's term_id instead of term object

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -30,7 +30,7 @@ function wpmenucache_get_transient_key( $args , $check_select = false ){
 
 		//Menu
 		if( isset( $args->menu ) && $args->menu ){
-			$menu_id = $args->menu;
+			$menu_id = $args->menu->term_id;
 		}
 		else{
 			if( $theme_location && has_nav_menu( $theme_location ) ){


### PR DESCRIPTION
Otherwise when setting `$key = "|$menu_id|$theme_location";`, the `$menu_id` would be a term object instead of the term ID.